### PR TITLE
Config option for tree harvesting max count

### DIFF
--- a/src/main/java/de/maxhenkel/reap/ServerConfig.java
+++ b/src/main/java/de/maxhenkel/reap/ServerConfig.java
@@ -21,6 +21,7 @@ public class ServerConfig extends ConfigBase {
     private final ForgeConfigSpec.ConfigValue<List<? extends String>> allowedTreeToolsSpec;
     public final ForgeConfigSpec.BooleanValue considerTool;
     public final ForgeConfigSpec.BooleanValue treeHarvest;
+    public final ForgeConfigSpec.IntValue treeHarvestMaxCount;
     public final ForgeConfigSpec.BooleanValue dynamicTreeBreakingEnabled;
     public final ForgeConfigSpec.DoubleValue dynamicTreeBreakingMinSpeed;
     public final ForgeConfigSpec.DoubleValue dynamicTreeBreakingPerLog;
@@ -84,6 +85,9 @@ public class ServerConfig extends ConfigBase {
         treeHarvest = builder
                 .comment("If the tree harvester should be enabled")
                 .define("tree_harvesting.enabled", true);
+        treeHarvestMaxCount = builder
+                .comment("The maximum amount of logs one harvest is allowed to do")
+                .defineInRange("tree_harvesting.max_harvesting_count", 128, 0, 1024);
         dynamicTreeBreakingEnabled = builder
                 .comment("If bigger trees should be harder to break")
                 .define("tree_harvesting.dynamic_breaking_speed.enabled", true);

--- a/src/main/java/de/maxhenkel/reap/TreeEvents.java
+++ b/src/main/java/de/maxhenkel/reap/TreeEvents.java
@@ -92,7 +92,8 @@ public class TreeEvents {
     }
 
     private static void collectLogs(Level world, BlockPos pos, BlockPosList positions) {
-        if (positions.size() >= 128) {
+        int maxHarvestingCount = Main.SERVER_CONFIG.treeHarvestMaxCount.get();
+        if (positions.size() >= maxHarvestingCount) {
             return;
         }
         List<BlockPos> posList = new ArrayList<>();
@@ -101,7 +102,7 @@ public class TreeEvents {
                 for (int z = -1; z <= 1; z++) {
                     BlockPos p = pos.offset(x, y, z);
                     if (isLog(world, p)) {
-                        if (positions.size() <= 128) {
+                        if (positions.size() <= maxHarvestingCount) {
                             if (positions.add(p)) {
                                 posList.add(p);
                             }


### PR DESCRIPTION
I've recently started using reap and felt the need to have a tree harvesting count other than 128.
This pull requst aims to add a server config option that lets the user specify the maximum number of logs harvested by tree harvesting.
The default value stays at 128 to ensure a seemless experience for existing users. Possible values are in the range of 0 to 1024.
