### PR TITLE
Better tree detection. Avoid mining manually placed logs.

### DIFF
--- a/src/main/java/de/maxhenkel/reap/ServerConfig.java
+++ b/src/main/java/de/maxhenkel/reap/ServerConfig.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public class ServerConfig extends ConfigBase {
 
     private final ModConfigSpec.ConfigValue<List<? extends String>> reapWhitelistSpec;
-//    private final ModConfigSpec.ConfigValue<List<? extends String>> logTypesSpec;
+    private final ModConfigSpec.ConfigValue<List<? extends String>> logTypesSpec;
 //    private final ModConfigSpec.ConfigValue<List<? extends String>> groundTypesSpec;
     private final ModConfigSpec.ConfigValue<List<? extends String>> allowedTreeToolsSpec;
     public final ModConfigSpec.BooleanValue considerTool;
@@ -43,21 +43,21 @@ public class ServerConfig extends ConfigBase {
                         "minecraft:beetroots",
                         "minecraft:cocoa"
                 ), Objects::nonNull);
-//        logTypesSpec = builder
-//                .comment("The log blocks that are allowed to get harvested by the tree harvester")
-//                .comment("Examples: 'minecraft:oak_log', '#minecraft:logs'")
-//                .defineList("tree_harvesting.log_types", Arrays.asList(
-//                        "minecraft:acacia_log",
-//                        "minecraft:birch_log",
-//                        "minecraft:dark_oak_log",
-//                        "minecraft:jungle_log",
-//                        "minecraft:oak_log",
-//                        "minecraft:spruce_log",
-//                        "minecraft:crimson_stem",
-//                        "minecraft:warped_stem",
-//                        "minecraft:mangrove_log",
-//                        "minecraft:cherry_log"
-//                ), Objects::nonNull);
+        logTypesSpec = builder
+                .comment("The log blocks that are allowed to get harvested by the tree harvester")
+                .comment("Examples: 'minecraft:oak_log', '#minecraft:logs'")
+                .defineList("tree_harvesting.log_types", Arrays.asList(
+                        "minecraft:acacia_log",
+                        "minecraft:birch_log",
+                        "minecraft:dark_oak_log",
+                        "minecraft:jungle_log",
+                        "minecraft:oak_log",
+                        "minecraft:spruce_log",
+                        "minecraft:crimson_stem",
+                        "minecraft:warped_stem",
+                        "minecraft:mangrove_log",
+                        "minecraft:cherry_log"
+                ), Objects::nonNull);
 //        groundTypesSpec = builder
 //                .comment("The blocks that are allowed below logs that can be harvested")
 //                .comment("Examples: 'minecraft:dirt', '#forge:sand/colorless'")
@@ -115,7 +115,7 @@ public class ServerConfig extends ConfigBase {
 
     private void onConfigChange() {
         reapWhitelist = reapWhitelistSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
-//        logTypes = logTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
+        logTypes = logTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
 //        groundTypes = groundTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
         allowedTreeTools = allowedTreeToolsSpec.get().stream().map(s -> TagUtils.getItem(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
     }

--- a/src/main/java/de/maxhenkel/reap/ServerConfig.java
+++ b/src/main/java/de/maxhenkel/reap/ServerConfig.java
@@ -17,7 +17,7 @@ public class ServerConfig extends ConfigBase {
 
     private final ModConfigSpec.ConfigValue<List<? extends String>> reapWhitelistSpec;
     private final ModConfigSpec.ConfigValue<List<? extends String>> logTypesSpec;
-//    private final ModConfigSpec.ConfigValue<List<? extends String>> groundTypesSpec;
+    private final ModConfigSpec.ConfigValue<List<? extends String>> groundTypesSpec;
     private final ModConfigSpec.ConfigValue<List<? extends String>> allowedTreeToolsSpec;
     public final ModConfigSpec.BooleanValue considerTool;
     public final ModConfigSpec.BooleanValue treeHarvest;
@@ -58,19 +58,19 @@ public class ServerConfig extends ConfigBase {
                         "minecraft:mangrove_log",
                         "minecraft:cherry_log"
                 ), Objects::nonNull);
-//        groundTypesSpec = builder
-//                .comment("The blocks that are allowed below logs that can be harvested")
-//                .comment("Examples: 'minecraft:dirt', '#forge:sand/colorless'")
-//                .defineList("tree_harvesting.ground_types", Arrays.asList(
-//                        "minecraft:dirt",
-//                        "minecraft:grass_block",
-//                        "minecraft:coarse_dirt",
-//                        "minecraft:podzol",
-//                        "minecraft:mycelium",
-//                        "minecraft:warped_nylium",
-//                        "minecraft:crimson_nylium",
-//                        "minecraft:netherrack"
-//                ), Objects::nonNull);
+        groundTypesSpec = builder
+                .comment("The blocks that are allowed below logs that can be harvested")
+                .comment("Examples: 'minecraft:dirt', '#forge:sand/colorless'")
+                .defineList("tree_harvesting.ground_types", Arrays.asList(
+                        "minecraft:dirt",
+                        "minecraft:grass_block",
+                        "minecraft:coarse_dirt",
+                        "minecraft:podzol",
+                        "minecraft:mycelium",
+                        "minecraft:warped_nylium",
+                        "minecraft:crimson_nylium",
+                        "minecraft:netherrack"
+                ), Objects::nonNull);
         allowedTreeToolsSpec = builder
                 .comment("The tools which the player is allowed to harvest trees")
                 .defineList("tree_harvesting.allowed_tree_tools", Arrays.asList(
@@ -116,8 +116,7 @@ public class ServerConfig extends ConfigBase {
     private void onConfigChange() {
         reapWhitelist = reapWhitelistSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
         logTypes = logTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
-//        groundTypes = groundTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
+        groundTypes = groundTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
         allowedTreeTools = allowedTreeToolsSpec.get().stream().map(s -> TagUtils.getItem(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
     }
-
 }

--- a/src/main/java/de/maxhenkel/reap/ServerConfig.java
+++ b/src/main/java/de/maxhenkel/reap/ServerConfig.java
@@ -16,8 +16,8 @@ import java.util.stream.Collectors;
 public class ServerConfig extends ConfigBase {
 
     private final ModConfigSpec.ConfigValue<List<? extends String>> reapWhitelistSpec;
-    private final ModConfigSpec.ConfigValue<List<? extends String>> logTypesSpec;
-    private final ModConfigSpec.ConfigValue<List<? extends String>> groundTypesSpec;
+//    private final ModConfigSpec.ConfigValue<List<? extends String>> logTypesSpec;
+//    private final ModConfigSpec.ConfigValue<List<? extends String>> groundTypesSpec;
     private final ModConfigSpec.ConfigValue<List<? extends String>> allowedTreeToolsSpec;
     public final ModConfigSpec.BooleanValue considerTool;
     public final ModConfigSpec.BooleanValue treeHarvest;
@@ -43,34 +43,34 @@ public class ServerConfig extends ConfigBase {
                         "minecraft:beetroots",
                         "minecraft:cocoa"
                 ), Objects::nonNull);
-        logTypesSpec = builder
-                .comment("The log blocks that are allowed to get harvested by the tree harvester")
-                .comment("Examples: 'minecraft:oak_log', '#minecraft:logs'")
-                .defineList("tree_harvesting.log_types", Arrays.asList(
-                        "minecraft:acacia_log",
-                        "minecraft:birch_log",
-                        "minecraft:dark_oak_log",
-                        "minecraft:jungle_log",
-                        "minecraft:oak_log",
-                        "minecraft:spruce_log",
-                        "minecraft:crimson_stem",
-                        "minecraft:warped_stem",
-                        "minecraft:mangrove_log",
-                        "minecraft:cherry_log"
-                ), Objects::nonNull);
-        groundTypesSpec = builder
-                .comment("The blocks that are allowed below logs that can be harvested")
-                .comment("Examples: 'minecraft:dirt', '#forge:sand/colorless'")
-                .defineList("tree_harvesting.ground_types", Arrays.asList(
-                        "minecraft:dirt",
-                        "minecraft:grass_block",
-                        "minecraft:coarse_dirt",
-                        "minecraft:podzol",
-                        "minecraft:mycelium",
-                        "minecraft:warped_nylium",
-                        "minecraft:crimson_nylium",
-                        "minecraft:netherrack"
-                ), Objects::nonNull);
+//        logTypesSpec = builder
+//                .comment("The log blocks that are allowed to get harvested by the tree harvester")
+//                .comment("Examples: 'minecraft:oak_log', '#minecraft:logs'")
+//                .defineList("tree_harvesting.log_types", Arrays.asList(
+//                        "minecraft:acacia_log",
+//                        "minecraft:birch_log",
+//                        "minecraft:dark_oak_log",
+//                        "minecraft:jungle_log",
+//                        "minecraft:oak_log",
+//                        "minecraft:spruce_log",
+//                        "minecraft:crimson_stem",
+//                        "minecraft:warped_stem",
+//                        "minecraft:mangrove_log",
+//                        "minecraft:cherry_log"
+//                ), Objects::nonNull);
+//        groundTypesSpec = builder
+//                .comment("The blocks that are allowed below logs that can be harvested")
+//                .comment("Examples: 'minecraft:dirt', '#forge:sand/colorless'")
+//                .defineList("tree_harvesting.ground_types", Arrays.asList(
+//                        "minecraft:dirt",
+//                        "minecraft:grass_block",
+//                        "minecraft:coarse_dirt",
+//                        "minecraft:podzol",
+//                        "minecraft:mycelium",
+//                        "minecraft:warped_nylium",
+//                        "minecraft:crimson_nylium",
+//                        "minecraft:netherrack"
+//                ), Objects::nonNull);
         allowedTreeToolsSpec = builder
                 .comment("The tools which the player is allowed to harvest trees")
                 .defineList("tree_harvesting.allowed_tree_tools", Arrays.asList(
@@ -115,8 +115,8 @@ public class ServerConfig extends ConfigBase {
 
     private void onConfigChange() {
         reapWhitelist = reapWhitelistSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
-        logTypes = logTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
-        groundTypes = groundTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
+//        logTypes = logTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
+//        groundTypes = groundTypesSpec.get().stream().map(s -> TagUtils.getBlock(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
         allowedTreeTools = allowedTreeToolsSpec.get().stream().map(s -> TagUtils.getItem(s, true)).filter(Objects::nonNull).collect(Collectors.toList());
     }
 

--- a/src/main/java/de/maxhenkel/reap/TreeEvents.java
+++ b/src/main/java/de/maxhenkel/reap/TreeEvents.java
@@ -1,18 +1,22 @@
 package de.maxhenkel.reap;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.RotatedPillarBlock;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.Property;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
 
-import java.util.ArrayList;
-import java.util.List;
+import javax.annotation.Nullable;
+import java.util.*;
 
 public class TreeEvents {
 
@@ -24,9 +28,8 @@ public class TreeEvents {
         }
         Player player = event.getPlayer();
         BlockPos pos = event.getPos();
-        ItemStack heldItem = player.getMainHandItem();
-        if (canHarvest(pos, player, world, heldItem)) {
-            destroyTree(player, world, pos, heldItem);
+        if (canHarvest(player)) {
+            destroyTree(player, world, pos);
         }
     }
 
@@ -40,13 +43,14 @@ public class TreeEvents {
         if (pos == null) {
             return;
         }
-        if (canHarvest(pos, player, player.level(), player.getMainHandItem())) {
-            List<BlockPos> connectedLogs = getConnectedLogs(player.level(), pos);
+        if (canHarvest(player)) {
+            LinkedList<BlockPos> connectedLogs = scanForTree(player.level(), pos);
             event.setNewSpeed((float) (event.getOriginalSpeed() / Math.min(1D + Main.SERVER_CONFIG.dynamicTreeBreakingPerLog.get() * connectedLogs.size(), Main.SERVER_CONFIG.dynamicTreeBreakingMinSpeed.get())));
         }
     }
 
-    public static boolean canHarvest(BlockPos pos, Player player, Level world, ItemStack heldItem) {
+    public static boolean canHarvest(Player player) {
+        ItemStack heldItem = player.getMainHandItem();
         if (player.getAbilities().instabuild) {
             return false;
         }
@@ -59,77 +63,18 @@ public class TreeEvents {
             return false;
         }
 
-        if (!isLog(world, pos)) {
-            return false;
-        }
-
-        if (!isGround(world, pos.below())) {
-            return false;
-        }
-
-        BlockState state = world.getBlockState(pos);
-        if (state.getProperties().stream().anyMatch(p -> p.equals(RotatedPillarBlock.AXIS))) {
-            if (!state.getValue(RotatedPillarBlock.AXIS).equals(Direction.Axis.Y)) {
-                return false;
-            }
-        }
-
         return true;
     }
 
-    private static void destroyTree(Player player, Level world, BlockPos pos, ItemStack heldItem) {
-        List<BlockPos> connectedLogs = getConnectedLogs(world, pos);
-
-        for (BlockPos logPos : connectedLogs) {
-            destroy(world, player, logPos, heldItem);
+    private void destroyTree(Player player, Level world, BlockPos pos) {
+        LinkedList<BlockPos> connectedLogs = scanForTree(world, pos);
+        for (BlockPos log : connectedLogs) {
+            destroy(world, player, log);
         }
     }
 
-    private static List<BlockPos> getConnectedLogs(Level world, BlockPos pos) {
-        BlockPosList positions = new BlockPosList();
-        collectLogs(world, pos, positions);
-        return positions;
-    }
-
-    private static void collectLogs(Level world, BlockPos pos, BlockPosList positions) {
-        int maxHarvestingCount = Main.SERVER_CONFIG.treeHarvestMaxCount.get();
-        if (positions.size() >= maxHarvestingCount) {
-            return;
-        }
-        List<BlockPos> posList = new ArrayList<>();
-        for (int x = -1; x <= 1; x++) {
-            for (int y = -1; y <= 1; y++) {
-                for (int z = -1; z <= 1; z++) {
-                    BlockPos p = pos.offset(x, y, z);
-                    if (isLog(world, p)) {
-                        if (positions.size() <= maxHarvestingCount) {
-                            if (positions.add(p)) {
-                                posList.add(p);
-                            }
-                        } else {
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-
-        for (BlockPos p : posList) {
-            collectLogs(world, p, positions);
-        }
-    }
-
-    private static boolean isLog(Level world, BlockPos pos) {
-        BlockState b = world.getBlockState(pos);
-        return Main.SERVER_CONFIG.logTypes.stream().anyMatch(tag -> tag.contains(b.getBlock()));
-    }
-
-    private static boolean isGround(Level world, BlockPos pos) {
-        BlockState b = world.getBlockState(pos);
-        return Main.SERVER_CONFIG.groundTypes.stream().anyMatch(tag -> tag.contains(b.getBlock()));
-    }
-
-    private static void destroy(Level world, Player player, BlockPos pos, ItemStack heldItem) {
+    private static void destroy(Level world, Player player, BlockPos pos) {
+        ItemStack heldItem = player.getMainHandItem();
         if (heldItem != null) {
             heldItem.getItem().mineBlock(heldItem, world, world.getBlockState(pos), pos, player);
             world.destroyBlock(pos, true);
@@ -137,19 +82,85 @@ public class TreeEvents {
         }
     }
 
-    private static class BlockPosList extends ArrayList<BlockPos> {
-        @Override
-        public boolean add(BlockPos pos) {
-            if (!contains(pos)) {
-                return super.add(pos);
-            }
-            return false;
+    // tree detector
+    public static LinkedList<BlockPos> scanForTree(final LevelReader level, final BlockPos start) {
+        final BlockState blockState = level.getBlockState(start);
+        if (!blockState.is(BlockTags.LOGS)) {
+            return new LinkedList<>();
         }
 
-        @Override
-        public boolean contains(Object o) {
-            return stream().anyMatch(pos1 -> pos1.equals(o));
-        }
+        final boolean[] leavesFound = new boolean[1];
+        final LinkedList<BlockPos> result =
+                recursiveSearch(level, start, (pos, bs, isRightBlock) -> {
+                    if (isLeaves(bs)) {
+                        leavesFound[0] = true;
+                    }
+                    return true;
+                });
+        return leavesFound[0] ? result : new LinkedList<>();
     }
 
+    // for internal use
+    private interface BlockAction {
+        boolean onBlock(BlockPos pos, BlockState state, boolean isRightBlock);
+    }
+
+    // Recursively scan 3x3x3 cubes while keeping track of already scanned blocks to avoid cycles.
+    private static LinkedList<BlockPos> recursiveSearch(final LevelReader world, final BlockPos start, @Nullable final BlockAction action) {
+        final Block wantedBlock = world.getBlockState(start).getBlock();
+        boolean abort = false;
+        final LinkedList<BlockPos> result = new LinkedList<>();
+        final Set<BlockPos> visited = new HashSet<>();
+        final LinkedList<BlockPos> queue = new LinkedList<>();
+        int maxHarvestingCount = Main.SERVER_CONFIG.treeHarvestMaxCount.get();
+        queue.push(start);
+
+        while (!queue.isEmpty()) {
+            final BlockPos center = queue.pop();
+            final int x0 = center.getX();
+            final int y0 = center.getY();
+            final int z0 = center.getZ();
+            for (int z = z0 - 1; z <= z0 + 1 && !abort; ++z) {
+                for (int y = y0 - 1; y <= y0 + 1 && !abort; ++y) {
+                    for (int x = x0 - 1; x <= x0 + 1 && !abort; ++x) {
+                        final BlockPos pos = new BlockPos(x, y, z);
+                        final BlockState bs = world.getBlockState(pos);
+                        if ((bs.isAir() || !visited.add(pos))) {
+                            continue;
+                        }
+                        final boolean isRightBlock = bs.is(wantedBlock);
+                        if (isRightBlock) {
+                            result.add(pos);
+                            if (queue.size() > maxHarvestingCount) {
+                                abort = true;
+                                break;
+                            }
+                            queue.push(pos);
+                        }
+                        if (action != null) {
+                            abort = !action.onBlock(pos, bs, isRightBlock);
+                        }
+                    }
+                }
+            }
+        }
+        return !abort ? result : new LinkedList<>();
+    }
+
+    // leaves detector
+    // Naturally generated leaves don't have BlockStateProperties.PERSISTENT property, meaning it's a real tree.
+    // If there is BlockStateProperties.PERSISTENT property, it means the leave block is placed by player, meaning it's not a natural tree.
+    private static boolean isLeaves(final BlockState blockState) {
+        if (!(blockState.getBlock() instanceof LeavesBlock)) {
+            return false;
+        }
+        final Collection<Property<?>> properties = blockState.getProperties();
+        if (properties.contains(BlockStateProperties.PERSISTENT)) {
+            final boolean persistent = blockState.getValue(BlockStateProperties.PERSISTENT);
+            if (persistent) {
+                return false;
+            }
+        }
+        return blockState.getBlock() instanceof LeavesBlock;
+    }
 }

--- a/src/main/java/de/maxhenkel/reap/TreeEvents.java
+++ b/src/main/java/de/maxhenkel/reap/TreeEvents.java
@@ -68,16 +68,12 @@ public class TreeEvents {
             return false;
         }
 
-//        if (!isGround(level, pos.below())) {
-//            return false;
-//        }
-
         return true;
     }
 
     private static boolean isLog(Level world, BlockPos pos) {
         BlockState b = world.getBlockState(pos);
-        return Main.SERVER_CONFIG.logTypes.stream().anyMatch(tag -> tag.contains(b.getBlock()));
+        return Main.SERVER_CONFIG.logTypes.stream().anyMatch(tag -> tag.contains(b.getBlock())) || b.is(BlockTags.LOGS);
     }
 
     private static boolean isGround(Level world, BlockPos pos) {
@@ -169,16 +165,15 @@ public class TreeEvents {
     // Naturally generated leaves don't have BlockStateProperties.PERSISTENT property, meaning it's a real tree.
     // If there is BlockStateProperties.PERSISTENT property, it means the leave block is placed by player, meaning it's not a natural tree.
     private static boolean isLeaves(final BlockState blockState) {
-//        if (!(blockState.getBlock() instanceof LeavesBlock)) {
-//            return false;
-//        }
-        final Collection<Property<?>> properties = blockState.getProperties();
-        if (properties.contains(BlockStateProperties.PERSISTENT)) {
-            final boolean persistent = blockState.getValue(BlockStateProperties.PERSISTENT);
-            if (persistent) {
-                return false;
+        if (blockState.getBlock() instanceof LeavesBlock) {
+            final Collection<Property<?>> properties = blockState.getProperties();
+            if (properties.contains(BlockStateProperties.PERSISTENT)) {
+                final boolean persistent = blockState.getValue(BlockStateProperties.PERSISTENT);
+                return !persistent;
             }
+            return true;
+        } else {
+            return blockState.is(BlockTags.WART_BLOCKS);
         }
-        return blockState.getBlock() instanceof LeavesBlock || blockState.is(BlockTags.WART_BLOCKS);
     }
 }

--- a/src/main/java/de/maxhenkel/reap/TreeEvents.java
+++ b/src/main/java/de/maxhenkel/reap/TreeEvents.java
@@ -102,13 +102,13 @@ public class TreeEvents {
     }
 
     // tree detector
-    public static LinkedList<BlockPos> scanForTree(final LevelReader level, final BlockPos start) {
+    public static LinkedList<BlockPos> scanForTree(LevelReader level, BlockPos start) {
         if (!isLog((Level) level, start)) {
             return new LinkedList<>();
         }
 
-        final boolean[] leavesFound = new boolean[1];
-        final LinkedList<BlockPos> result =
+        boolean[] leavesFound = new boolean[1];
+        LinkedList<BlockPos> result =
                 recursiveSearch(level, start, (pos, bs, isRightBlock) -> {
                     if (isLeaves(bs)) {
                         leavesFound[0] = true;
@@ -124,29 +124,29 @@ public class TreeEvents {
     }
 
     // Recursively scan 3x3x3 cubes while keeping track of already scanned blocks to avoid cycles.
-    private static LinkedList<BlockPos> recursiveSearch(final LevelReader world, final BlockPos start, @Nullable final BlockAction action) {
-        final Block wantedBlock = world.getBlockState(start).getBlock();
+    private static LinkedList<BlockPos> recursiveSearch(LevelReader world, BlockPos start, @Nullable BlockAction action) {
+        Block wantedBlock = world.getBlockState(start).getBlock();
         boolean abort = false;
-        final LinkedList<BlockPos> result = new LinkedList<>();
-        final Set<BlockPos> visited = new HashSet<>();
-        final LinkedList<BlockPos> queue = new LinkedList<>();
+        LinkedList<BlockPos> result = new LinkedList<>();
+        Set<BlockPos> visited = new HashSet<>();
+        LinkedList<BlockPos> queue = new LinkedList<>();
         int maxHarvestingCount = Main.SERVER_CONFIG.treeHarvestMaxCount.get();
         queue.push(start);
 
         while (!queue.isEmpty()) {
-            final BlockPos center = queue.pop();
-            final int x0 = center.getX();
-            final int y0 = center.getY();
-            final int z0 = center.getZ();
+            BlockPos center = queue.pop();
+            int x0 = center.getX();
+            int y0 = center.getY();
+            int z0 = center.getZ();
             for (int z = z0 - 1; z <= z0 + 1 && !abort; ++z) {
                 for (int y = y0 - 1; y <= y0 + 1 && !abort; ++y) {
                     for (int x = x0 - 1; x <= x0 + 1 && !abort; ++x) {
-                        final BlockPos pos = new BlockPos(x, y, z);
-                        final BlockState bs = world.getBlockState(pos);
+                        BlockPos pos = new BlockPos(x, y, z);
+                        BlockState bs = world.getBlockState(pos);
                         if ((bs.isAir() || !visited.add(pos))) {
                             continue;
                         }
-                        final boolean isRightBlock = bs.is(wantedBlock);
+                        boolean isRightBlock = bs.is(wantedBlock);
                         if (isRightBlock) {
                             result.add(pos);
                             if (queue.size() > maxHarvestingCount) {
@@ -168,12 +168,11 @@ public class TreeEvents {
     // leaves detector
     // Naturally generated leaves don't have BlockStateProperties.PERSISTENT property, meaning it's a real tree.
     // If there is BlockStateProperties.PERSISTENT property, it means the leave block is placed by player, meaning it's not a natural tree.
-    private static boolean isLeaves(final BlockState blockState) {
+    private static boolean isLeaves(BlockState blockState) {
         if (blockState.getBlock() instanceof LeavesBlock) {
-            final Collection<Property<?>> properties = blockState.getProperties();
+            Collection<Property<?>> properties = blockState.getProperties();
             if (properties.contains(BlockStateProperties.PERSISTENT)) {
-                final boolean persistent = blockState.getValue(BlockStateProperties.PERSISTENT);
-                return !persistent;
+                return !blockState.getValue(BlockStateProperties.PERSISTENT);
             }
             return true;
         } else {

--- a/src/main/java/de/maxhenkel/reap/TreeEvents.java
+++ b/src/main/java/de/maxhenkel/reap/TreeEvents.java
@@ -68,6 +68,10 @@ public class TreeEvents {
             return false;
         }
 
+        if (!isGround(level, pos.below())) {
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Hi,
Current implementation makes manually placed logs valid for treeCapitator event. This will break any blocks that are manually placed above `VALID_GROUND`, which is not ok.
One (and only?) way to prevent that is to check for leaves around. This however would cause the same behavior when there are manually placed leaves.
Now, thanks to the `BlockStateProperties.PERSISTENT` property, we can easily detect if the leave block is placed by player or naturally generated.
![image](https://github.com/user-attachments/assets/fbeea2dd-0572-4c6f-bbc7-173772b69dc7)
![image](https://github.com/user-attachments/assets/0b177173-34d7-4fa8-93e5-d1cfa99c12f6)

Now, all we have to do, is check for these leaves around and cut the log if true.

More clear view over the `TreeEvents`: (because git's view might be confusing.) 
https://github.com/CrossVas/reap/blob/4a6a8a814049b353ac8fd99b1e30a7be4b17d176/src/main/java/de/maxhenkel/reap/TreeEvents.java 

This fix should work on previous versions as well.

UPD: I'm using this fix on 1.20.1 on my local server for several days and it works as intended so far. Also we have BOP and it works on modded logs as well. 

UPD2: Also this will check the size of the tree first. If the final count is greater than maxCount, the tree won't be chopped, meaning you have to increase the maxCount in config. This will prevent this kind of situations:
![2024-08-20_10 07 47](https://github.com/user-attachments/assets/cfb709a8-ac11-4a5a-99b9-58ba3f7cf3fd)
